### PR TITLE
fix(apps): prevent indefinite skeleton loader on client-side navigation

### DIFF
--- a/view/packages/hooks/applications/use_get_deployed_applications.ts
+++ b/view/packages/hooks/applications/use_get_deployed_applications.ts
@@ -128,7 +128,9 @@ function useGetDeployedApplications() {
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
 
   useEffect(() => {
-    getSelfHosted().then(setSelfHosted);
+    getSelfHosted()
+      .then(setSelfHosted)
+      .catch(() => setSelfHosted(false));
   }, []);
 
   useEffect(() => {

--- a/view/redux/conf.ts
+++ b/view/redux/conf.ts
@@ -56,6 +56,10 @@ async function fetchConfig() {
         }
         configPromise = null;
         throw new Error('Invalid config: missing baseUrl');
+      })
+      .catch((err) => {
+        configPromise = null;
+        throw err;
       });
   }
   return configPromise;


### PR DESCRIPTION
#### Issue
Fixes #1349

---

#### Description
The Apps page (`/apps`) shows its skeleton loader forever when reached via
client-side navigation from another page; a full refresh loads it fine.

Root cause is in the app config loader. `fetchConfig()` in `view/redux/conf.ts`
memoizes an in-flight `configPromise`, but only clears it on the "fetch succeeded
with invalid config" path. If the fetch itself rejects (network error, or a
non-JSON response like an HTML error page), the rejected promise stays cached for
the whole session, so every later `getSelfHosted()` / `getBaseUrl()` call reuses
a promise that can never resolve. On a fresh load the module state is reset so it
works; on client-side navigation the poisoned promise persists, which is the
refresh-works / navigate-fails asymmetry.

On the Apps page, `selfHosted` is initialized to `null` and only ever set via
`getSelfHosted().then(setSelfHosted)` with no rejection handling, so when that
promise rejects `selfHosted` stays `null` and the render gate
`selfHosted === null || isLoadingApplications || isLoading` never opens.

This PR fixes both layers:
- `conf.ts`: add a `.catch` that resets `configPromise = null` and rethrows, so a
  failed config fetch no longer poisons the cache and the next call can retry.
- `use_get_deployed_applications.ts`: add `.catch(() => setSelfHosted(false))` so a
  failed config lookup resolves the skeleton gate (managed-mode fallback) instead
  of hanging indefinitely.

---

#### Scope of Change
- [x] View (UI/UX)
- [ ] API
- [ ] CLI
- [ ] Infra / Deployment
- [ ] Docs
- [ ] Other (specify): ________

---

#### Screenshot / Video / GIF (if applicable)
Before: navigating to /apps from another page shows the skeleton indefinitely.
After: /apps renders correctly via client-side navigation without a refresh.
_(attaching a short before/after screen recording)_

---

#### Related PRs (if any)
#1350 targets the same issue with a similar approach.

---

#### Additional Notes for Reviewers (optional)
No env vars or setup changes. Repro: load any page other than /apps, then
navigate to /apps client-side while the config fetch is failing (e.g. throttle or
block `/api/config` in devtools) — on `master` the skeleton never resolves; with
this change it recovers. The `conf.ts` catch rethrows after resetting, so existing
callers still see the rejection for the current call while future calls can retry.

---

#### Developer Checklist
- [x] Add valid/relevant title for the PR
- [x] Self-review done
- [x] Manual dev testing done
- [ ] No secrets exposed
- [x] No merge conflicts
- [ ] Docs added/updated (if applicable)
- [x] Removed debug prints / secrets / sensitive data
- [ ] Unit / Integration tests passing
- [x] Follows all standards defined in **Nixopus Docs**

---

#### Reviewer Checklist
_To be completed by the reviewer before merge._
- [ ] Peer review done
- [ ] No console.logs / fmt.prints left
- [ ] No secrets exposed
- [ ] If any DB migrations, migration changes are verified
- [ ] Verified release changes are production-ready

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application loading so failed self-hosted checks now safely default to `false` instead of leaving the state unset.
  * Fixed configuration loading so a failed request no longer leaves a stale in-progress state, helping future retries work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->