### PR TITLE
fix(auth): stop a stale session cookie from locking users out of login

### DIFF
--- a/view/app/api/session-cleanup/route.ts
+++ b/view/app/api/session-cleanup/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * Expires Better Auth cookies across every scope they could be stored under.
+ *
+ * Sign-out deletes cookies using the attributes configured right now. A cookie
+ * stored under a different domain or path — left by an AUTH_COOKIE_DOMAIN
+ * change, or by the app being reachable on both the apex and a subdomain — is
+ * a different cookie to the browser, so that deletion never matches it. The
+ * orphan keeps being sent and no client code can remove it, because HttpOnly
+ * cookies are unwritable from document.cookie. Only a server response clears
+ * them.
+ */
+
+const BASE_PATH = process.env.BASE_PATH || '';
+
+const BASE_COOKIE_NAMES = [
+  'better-auth.session_token',
+  'better-auth.session_data',
+  'better-auth.dont_remember'
+];
+
+// A cookie at /auth is not sent to /chats and is not cleared by a Path=/
+// deletion, so cover the auth landings as well as the root.
+const PATHS = ['/', '/auth', '/login', '/register'].flatMap((path) =>
+  BASE_PATH ? [path, `${BASE_PATH}${path === '/' ? '/' : path}`] : [path]
+);
+
+const SECURE_PREFIX = '__Secure-';
+const COOKIE_PREFIX = 'better-auth.';
+
+function isSameOrigin(request: NextRequest): boolean {
+  const origin = request.headers.get('origin');
+  if (!origin) return true; // Same-origin GET/POST may omit Origin entirely.
+  try {
+    return new URL(origin).host === request.headers.get('host');
+  } catch {
+    return false;
+  }
+}
+
+function isSecureRequest(request: NextRequest): boolean {
+  const forwarded = request.headers.get('x-forwarded-proto');
+  if (forwarded) return forwarded.split(',')[0].trim() === 'https';
+  return request.nextUrl.protocol === 'https:';
+}
+
+// The known names plus any Better Auth cookie this browser actually sent,
+// which picks up chunked variants (session_data.0, session_data.1, ...)
+// without emitting headers for chunks that do not exist.
+function cookieNames(request: NextRequest, secure: boolean): string[] {
+  const names = new Set(BASE_COOKIE_NAMES);
+
+  for (const cookie of request.cookies.getAll()) {
+    const bare = cookie.name.startsWith(SECURE_PREFIX)
+      ? cookie.name.slice(SECURE_PREFIX.length)
+      : cookie.name;
+    if (bare.startsWith(COOKIE_PREFIX)) names.add(bare);
+  }
+
+  // A __Secure- cookie can only be set over https, so only clear one when the
+  // request is secure — otherwise the browser rejects the header.
+  return secure ? [...names].flatMap((n) => [n, `${SECURE_PREFIX}${n}`]) : [...names];
+}
+
+// Host-only (undefined) plus every parent domain the cookie could be scoped
+// to: app.example.com yields undefined, .app.example.com, .example.com. Stops
+// at two labels so we never target a public suffix like .com, which browsers
+// reject. localhost and bare IPs cannot carry domain cookies at all.
+function candidateDomains(host: string | null): (string | undefined)[] {
+  const hostname = (host || '').split(':')[0].toLowerCase();
+  const domains: (string | undefined)[] = [undefined];
+
+  if (!hostname || hostname === 'localhost' || /^[\d.]+$/.test(hostname)) {
+    return domains;
+  }
+
+  const labels = hostname.split('.');
+  for (let i = 0; i <= labels.length - 2; i++) {
+    domains.push(`.${labels.slice(i).join('.')}`);
+  }
+  return domains;
+}
+
+function expiredCookie(name: string, path: string, domain: string | undefined): string {
+  const parts = [`${name}=`, 'Max-Age=0', 'Expires=Thu, 01 Jan 1970 00:00:00 GMT', `Path=${path}`];
+  if (domain) parts.push(`Domain=${domain}`);
+  parts.push('HttpOnly', 'SameSite=Lax');
+  // Browsers reject a __Secure- cookie set without Secure, which would make
+  // the deletion silently do nothing.
+  if (name.startsWith(SECURE_PREFIX)) parts.push('Secure');
+  return parts.join('; ');
+}
+
+export async function POST(request: NextRequest) {
+  // Without this a cross-site POST could force-log-out a signed-in user.
+  if (!isSameOrigin(request)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const response = NextResponse.json({ cleared: true });
+  const secure = isSecureRequest(request);
+  const domains = candidateDomains(request.headers.get('host'));
+
+  for (const name of cookieNames(request, secure)) {
+    for (const path of PATHS) {
+      for (const domain of domains) {
+        response.headers.append('Set-Cookie', expiredCookie(name, path, domain));
+      }
+    }
+  }
+
+  return response;
+}

--- a/view/app/client-layout.tsx
+++ b/view/app/client-layout.tsx
@@ -5,7 +5,7 @@ import { PersistGate } from 'redux-persist/integration/react';
 import { store, persistor } from '@/redux/store';
 import { Toaster } from '@nixopus/ui';
 import { useAppDispatch, useAppSelector } from '@/redux/hooks';
-import { useEffect, useState, useMemo, Suspense } from 'react';
+import { useEffect, useState, useMemo, useRef, Suspense } from 'react';
 import { initializeAuth } from '@/redux/features/users/authSlice';
 import { preloadBaseUrl } from '@/redux/base-query';
 import { usePathname, useRouter } from 'next/navigation';
@@ -14,6 +14,7 @@ import { FeatureFlagsProvider } from '@/packages/hooks/shared/features_provider'
 import { SystemStatsProvider } from '@/packages/hooks/shared/system-stats-provider';
 import { palette } from '@/packages/utils/colors';
 import { authClient } from '@/packages/lib/auth-client';
+import { clearStaleAuthCookies } from '@/packages/lib/session-cleanup';
 import AppLayout from '@/packages/layouts/layout';
 import { SudoModeProvider } from '@/packages/hooks/security/use-sudo-mode';
 import { MachineProvider } from '@/packages/contexts/machine-context';
@@ -151,6 +152,7 @@ const ChildrenWrapper = ({ children }: { children: React.ReactNode }) => {
   const authState = useAppSelector((state) => state.auth);
   const { isAuthenticated, isInitialized, user } = authState;
   const [isLoading, setIsLoading] = useState(true);
+  const hasPurgedStaleCookies = useRef(false);
 
   const isPublicRoute = useMemo(
     () => PUBLIC_ROUTES.some((route) => pathname === route || pathname.startsWith(route + '/')),
@@ -195,6 +197,11 @@ const ChildrenWrapper = ({ children }: { children: React.ReactNode }) => {
         const hasSession = !!session?.data?.session;
         if (hasSession && !isAuthenticated) {
           await dispatch(initializeAuth() as any);
+        } else if (!hasSession && !hasPurgedStaleCookies.current) {
+          // No valid session, so any Better Auth cookie left on this browser is
+          // stale. Clearing it here recovers users whose sign-out could not.
+          hasPurgedStaleCookies.current = true;
+          await clearStaleAuthCookies();
         }
       } catch {
         // Session check failed, rely on Redux state

--- a/view/middleware.ts
+++ b/view/middleware.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { getSessionCookie } from 'better-auth/cookies';
 import { getPluginPrivatePaths, getPluginPublicPaths } from '@/plugins/registry';
 
-const AUTH_COOKIE = 'better-auth.session_token';
 const BASE_PATH = process.env.BASE_PATH || '';
 
 const CORE_PUBLIC_PATHS = ['/auth', '/login', '/register', '/reset-password', '/verify-email'];
@@ -41,15 +41,13 @@ function isPrivatePath(path: string) {
 
 export function middleware(request: NextRequest) {
   const path = getPath(request.nextUrl.pathname);
-  const hasAuth = !!request.cookies.get(AUTH_COOKIE)?.value;
-
-  const isAuthLanding =
-    path === '/' || path === '/auth' || path === '/login' || path === '/register';
-  if (hasAuth && isAuthLanding) {
-    const url = request.nextUrl.clone();
-    url.pathname = BASE_PATH ? `${BASE_PATH}/chats` : '/chats';
-    return NextResponse.redirect(url);
-  }
+  // A session cookie may be expired, revoked, or an orphan left at a scope
+  // sign-out cannot clear, so it only gates private pages — never redirects
+  // anyone off the login page, which would make a stale cookie loop
+  // /auth -> /chats -> /auth until the browser gives up. Sending a signed-in
+  // user to /chats is client-layout.tsx's job; it checks a verified session.
+  // getSessionCookie() also matches the __Secure- prefixed name.
+  const hasAuth = !!getSessionCookie(request);
 
   const isAuthBypass = AUTH_BYPASS_PATHS.some((p) => path === p || path.startsWith(p + '/'));
   if (!hasAuth && (path === '/' || isPrivatePath(path)) && !isPublicPath(path) && !isAuthBypass) {

--- a/view/packages/lib/session-cleanup.ts
+++ b/view/packages/lib/session-cleanup.ts
@@ -1,0 +1,23 @@
+/**
+ * Asks the server to expire Better Auth cookies across every scope they could
+ * be stored under. See app/api/session-cleanup/route.ts for why sign-out alone
+ * cannot always reach them.
+ *
+ * Best effort: a failure here must never block signing out or rendering the
+ * login page.
+ */
+export async function clearStaleAuthCookies(): Promise<void> {
+  if (typeof window === 'undefined') return;
+
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+
+  try {
+    await fetch(`${basePath}/api/session-cleanup`, {
+      method: 'POST',
+      credentials: 'include',
+      cache: 'no-store'
+    });
+  } catch {
+    // Offline or blocked; the local sign-out still proceeds.
+  }
+}

--- a/view/redux/features/users/authSlice.ts
+++ b/view/redux/features/users/authSlice.ts
@@ -6,6 +6,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { REHYDRATE } from 'redux-persist';
 import { authClient } from '@/packages/lib/auth-client';
+import { clearStaleAuthCookies } from '@/packages/lib/session-cleanup';
 import { setActiveOrganization } from './userSlice';
 import { fetchUserOrganizations } from './orgSlice';
 
@@ -77,6 +78,12 @@ export const logoutUser = createAsyncThunk('auth/logoutUser', async (_, { dispat
     await authClient.signOut();
   } catch (error) {
     console.error('Better Auth logout failed:', error);
+  }
+
+  try {
+    // Runs even when signOut() failed, and clears cookies its response could
+    // not reach: ones scoped to a domain or path the config does not target.
+    await clearStaleAuthCookies();
   } finally {
     if (typeof window !== 'undefined') {
       localStorage.clear();


### PR DESCRIPTION
#### Issue
_Link to related issue(s):_  Reported in production: after logging out, the same browser can never log back in; an incognito window works.

---

#### Description
`middleware.ts` treated the presence of `better-auth.session_token` as proof of a session and redirected `/auth`, `/login`, `/register` and `/` to `/chats`. Any leftover cookie value therefore made login unreachable:

```
GET /auth   -> 307 /chats     (middleware sees a cookie, assumes signed in)
GET /chats  -> 307 /auth      (no valid session, client-layout sends them back)
GET /auth   -> 307 /chats     ...
```

The browser aborts with `ERR_TOO_MANY_REDIRECTS`, the login form never renders, and because no app code runs on those pages nothing can clear the cookie. It is self-perpetuating. Incognito works because it carries no cookie.

Sign-out normally clears the cookie, and Better Auth clears it by itself when it validates a token whose session is gone. Neither can reach a cookie stored under a **different domain or path** — left behind by an `AUTH_COOKIE_DOMAIN` change, or by the app being served on both an apex and a subdomain — because the expiry attributes no longer match the stored cookie. HttpOnly cookies also cannot be removed from `document.cookie`, so only a server response can clear them.

Changes:

- **`middleware.ts`** — drop the cookie-presence redirect off the login pages. The cookie now only gates private routes, which fails safe. Redirecting a signed-in user to `/chats` was already handled in `client-layout.tsx` against a *verified* session. The cookie is read with `getSessionCookie()` so the `__Secure-` prefixed name is matched when secure cookies are enabled.
- **`app/api/session-cleanup/route.ts`** (new) — expires every Better Auth cookie across host-only and parent domains (`app.example.com` -> `.app.example.com`, `.example.com`) and across `/`, `/auth`, `/login`, `/register`. Same-origin only, so it cannot be used to force a sign-out.
- **`authSlice.ts`** — logout calls the purge even when `signOut()` fails, which previously left the cookie behind.
- **`client-layout.tsx`** — the login page calls the purge when the session check comes back empty. This is what recovers users who are **already** locked out in production: once the middleware lets them reach `/auth`, their orphaned cookie is cleared on arrival.

---

#### Scope of Change
_Select all applicable areas impacted by this PR:_

- [x] View (UI/UX)
- [ ] API
- [ ] CLI
- [ ] Infra / Deployment
- [ ] Docs
- [ ] Other (specify): ________

---

#### Screenshot / Video / GIF (if applicable)
Reproduced against the live stack (postgres, redis, auth on `:9090`, api on `:8080`, next on `:3000`) by planting an orphaned same-name cookie at a scope sign-out cannot reach, then opening the login page.

Before — the browser network log ping-pongs until Chromium aborts:

```
GET http://localhost:3000/auth  -> 307
GET http://localhost:3000/chats -> 307
GET http://localhost:3000/auth  -> 307
GET http://localhost:3000/chats -> 307
...  chrome-error://chromewebdata/  (ERR_TOO_MANY_REDIRECTS)
```

curl, same cookie: `redirects_followed=10, status=307`, never resolves.

After: `final=/auth, redirects=0, status=200`, login form renders, orphan purged, login succeeds on the same browser.

---

#### Related PRs (if any)
None.

---

#### Additional Notes for Reviewers (optional)

No environment variables or migrations. Nothing to configure; the cleanup endpoint is same-origin only and requires no auth (it can only expire cookies).

Two related findings left out of this PR, both deliberate and worth deciding separately:

1. `useSecureCookies` in the auth service is `process.env.AUTH_SECURE_COOKIES === 'true'`, always a concrete boolean. Left `undefined`, Better Auth enables secure cookies automatically for https/production. As configured, production session cookies carry **no `Secure` flag**. Changing this renames the cookie to `__Secure-better-auth.session_token`, which is exactly why the middleware here now reads it via `getSessionCookie()` — this PR should land first.
2. `session.cookieCache` is enabled with a 5 minute `maxAge`. During the repro, `getSession` returned a complete session for a row that had already been deleted, for the full 5 minutes. Revoking a session does not take effect immediately.

Two pre-existing issues that block the e2e suite from running locally (unrelated to this change, not fixed here):

- `tests/e2e/global.setup.ts` posts to `/api/auth/sign-up/email` without an `Origin` header, so the auth service rejects it with `403 MISSING_OR_NULL_ORIGIN` and seeding can never succeed.
- Sign-up returns `500` from the DodoPayments hook when the API key is a placeholder, *after* the user row is committed.

To run the suite I seeded the auth state directly and used `npx playwright test --project=chromium --no-deps`.

---

#### Developer Checklist
_To be completed by the developer who raised the PR._

- [x] Add valid/relevant title for the PR
- [x] Self-review done  
- [x] Manual dev testing done  
- [x] No secrets exposed  
- [x] No merge conflicts  
- [ ] Docs added/updated (if applicable)  
- [x] Removed debug prints / secrets / sensitive data  
- [x] Unit / Integration tests passing  
- [x] Follows all standards defined in **Nixopus Docs**

Verification run: production build passes (middleware bundles to 35 kB with the new edge import, `/api/session-cleanup` present in the route manifest), `tsc` clean, eslint clean, prettier clean, 17 unit tests pass, and all 31 Playwright e2e tests pass including both logout flows and the authenticated `/auth -> /chats` redirect that this PR moves client-side.

---

#### Reviewer Checklist
_To be completed by the reviewer before merge._

- [ ] Peer review done  
- [ ] No console.logs / fmt.prints left  
- [ ] No secrets exposed  
- [ ] If any DB migrations, migration changes are verified
- [ ] Verified release changes are production-ready


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sign-out cleanup by removing stale authentication cookies, including cookies left behind after an unsuccessful sign-out.
  - Authentication checks now recognize supported session cookie variants more reliably.
  - Unauthenticated visitors continue to be redirected away from protected pages.
  - Authenticated visitors are no longer automatically redirected from login-related pages, allowing those pages to be opened directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->